### PR TITLE
Raises RuntimeException instead of fatal error when accessing a non-s…

### DIFF
--- a/Node/GetAttrNode.php
+++ b/Node/GetAttrNode.php
@@ -70,6 +70,10 @@ class GetAttrNode extends Node
 
                 $property = $this->nodes['attribute']->attributes['value'];
 
+                if (!property_exists($obj, $property) && !method_exists($obj, '__get')) {
+                    throw new \RuntimeException('Unable to get a non-supported property.');
+                }
+
                 return $obj->$property;
 
             case self::METHOD_CALL:

--- a/Tests/Node/GetAttrNodeTest.php
+++ b/Tests/Node/GetAttrNodeTest.php
@@ -44,6 +44,24 @@ class GetAttrNodeTest extends AbstractNodeTest
         );
     }
 
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Unable to get a non-supported property.
+     */
+    public function testAccessorException()
+    {
+        $node = new GetAttrNode(
+            new NameNode('foo'),
+            new ConstantNode('baz'),
+            $this->getArrayNode(),
+            GetAttrNode::PROPERTY_CALL
+        );
+        $variables = array('foo' => new Obj());
+        $functions = [];
+
+        $node->evaluate($functions, $variables);
+    }
+
     protected function getArrayNode()
     {
         $array = new ArrayNode();


### PR DESCRIPTION
…upported arguments of an object


I would like expression language to be able to raise a proper exception instead of a fatal error when the expression tries to access a non-existent property or a non supported (through `__get`method) property.

This would be usefull in a product that does rely on the Expression Language engine to give to the final user some controls on the business logic to satisfie before triggering some actions. When they do so, they can use variables on object that does not exists and an Exception would make this use case catchable.