### PR TITLE
[ExpressionLanguage][FEATURE] Add support for Nullsafe syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+6.0.0
+-----
+
+ * added support of `nullsafe operator` syntax when parsing object's properties
+ * added support of `nullsafe operator` syntax when parsing object's methods
+
 5.1.0
 -----
 

--- a/Node/ConstantNode.php
+++ b/Node/ConstantNode.php
@@ -21,10 +21,12 @@ use Symfony\Component\ExpressionLanguage\Compiler;
 class ConstantNode extends Node
 {
     private $isIdentifier;
+    public $isNullSafe;
 
-    public function __construct($value, bool $isIdentifier = false)
+    public function __construct($value, bool $isIdentifier = false, bool $isNullSafe = false)
     {
         $this->isIdentifier = $isIdentifier;
+        $this->isNullSafe = $isNullSafe;
         parent::__construct(
             [],
             ['value' => $value]

--- a/Node/GetAttrNode.php
+++ b/Node/GetAttrNode.php
@@ -75,6 +75,10 @@ class GetAttrNode extends Node
 
                 $property = $this->nodes['attribute']->attributes['value'];
 
+                if ($this->nodes['attribute']->isNullSafe) {
+                    return $obj->$property ?? null;
+                }
+
                 return $obj->$property;
 
             case self::METHOD_CALL:
@@ -83,6 +87,9 @@ class GetAttrNode extends Node
                     throw new \RuntimeException(sprintf('Unable to call method "%s" of non-object "%s".', $this->nodes['attribute']->dump(), $this->nodes['node']->dump()));
                 }
                 if (!\is_callable($toCall = [$obj, $this->nodes['attribute']->attributes['value']])) {
+                    if ($this->nodes['attribute']->isNullSafe) {
+                        return null;
+                    }
                     throw new \RuntimeException(sprintf('Unable to call method "%s" of object "%s".', $this->nodes['attribute']->attributes['value'], get_debug_type($obj)));
                 }
 

--- a/Node/GetAttrNode.php
+++ b/Node/GetAttrNode.php
@@ -34,11 +34,12 @@ class GetAttrNode extends Node
 
     public function compile(Compiler $compiler)
     {
+        $nullSafe = $this->nodes['attribute'] instanceof ConstantNode ? $this->nodes['attribute']->isNullSafe : false;
         switch ($this->attributes['type']) {
             case self::PROPERTY_CALL:
                 $compiler
                     ->compile($this->nodes['node'])
-                    ->raw('->')
+                    ->raw($nullSafe ? '?->' : '->')
                     ->raw($this->nodes['attribute']->attributes['value'])
                 ;
                 break;
@@ -46,7 +47,7 @@ class GetAttrNode extends Node
             case self::METHOD_CALL:
                 $compiler
                     ->compile($this->nodes['node'])
-                    ->raw('->')
+                    ->raw($nullSafe ? '?->' : '->')
                     ->raw($this->nodes['attribute']->attributes['value'])
                     ->raw('(')
                     ->compile($this->nodes['arguments'])

--- a/Parser.php
+++ b/Parser.php
@@ -331,11 +331,17 @@ class Parser
         return $node;
     }
 
-    public function parsePostfixExpression(Node\Node $node)
+    public function parsePostfixExpression(Node\Node $node, bool $isNullSafe = false)
     {
         $token = $this->stream->current;
         while (Token::PUNCTUATION_TYPE == $token->type) {
-            if ('.' === $token->value) {
+            if ('?' === $token->value) {
+                $this->stream->next();
+                $token = $this->stream->current;
+                if ('.' === $token->value) {
+                    $node = $this->parsePostfixExpression($node, true);
+                }
+            } elseif ('.' === $token->value) {
                 $this->stream->next();
                 $token = $this->stream->current;
                 $this->stream->next();
@@ -359,7 +365,7 @@ class Parser
                     throw new SyntaxError('Expected name.', $token->cursor, $this->stream->getExpression());
                 }
 
-                $arg = new Node\ConstantNode($token->value, true);
+                $arg = new Node\ConstantNode($token->value, true, $isNullSafe);
 
                 $arguments = new Node\ArgumentsNode();
                 if ($this->stream->current->test(Token::PUNCTUATION_TYPE, '(')) {

--- a/Parser.php
+++ b/Parser.php
@@ -340,6 +340,8 @@ class Parser
                 $token = $this->stream->current;
                 if ('.' === $token->value) {
                     $node = $this->parsePostfixExpression($node, true);
+                } else {
+                    $node = $this->parseExpression();
                 }
             } elseif ('.' === $token->value) {
                 $this->stream->next();

--- a/Tests/ExpressionLanguageTest.php
+++ b/Tests/ExpressionLanguageTest.php
@@ -245,6 +245,13 @@ class ExpressionLanguageTest extends TestCase
         $el->evaluate('foo.myfunction()', ['foo' => new \stdClass()]);
     }
 
+    public function testCallBadCallableWithNullSafe()
+    {
+        $el = new ExpressionLanguage();
+        $result = $el->evaluate('foo?.myfunction()', ['foo' => new \stdClass()]);
+        $this->assertNull($result);
+    }
+
     /**
      * @dataProvider getRegisterCallbacks
      */

--- a/Tests/ParserTest.php
+++ b/Tests/ParserTest.php
@@ -136,6 +136,21 @@ class ParserTest extends TestCase
                 new Node\BinaryNode('matches', new Node\ConstantNode('foo'), new Node\ConstantNode('/foo/')),
                 '"foo" matches "/foo/"',
             ],
+            [
+                new Node\GetAttrNode(new Node\NameNode('foo'), new Node\ConstantNode('bar', true, true), new Node\ArgumentsNode(), Node\GetAttrNode::PROPERTY_CALL),
+                'foo?.bar',
+                ['foo'],
+            ],
+            [
+                new Node\GetAttrNode(new Node\NameNode('foo'), new Node\ConstantNode('bar', true, true), new Node\ArgumentsNode(), Node\GetAttrNode::METHOD_CALL),
+                'foo?.bar()',
+                ['foo'],
+            ],
+            [
+                new Node\GetAttrNode(new Node\NameNode('foo'), new Node\ConstantNode('not', true, true), new Node\ArgumentsNode(), Node\GetAttrNode::METHOD_CALL),
+                'foo?.not()',
+                ['foo'],
+            ],
 
             // chained calls
             [
@@ -263,6 +278,10 @@ class ParserTest extends TestCase
         return [
             'valid expression' => [
                 'expression' => 'foo["some_key"].callFunction(a ? b)',
+                'names' => ['foo', 'a', 'b'],
+            ],
+            'valid expression with null safety' => [
+                'expression' => 'foo["some_key"]?.callFunction(a ? b)',
                 'names' => ['foo', 'a', 'b'],
             ],
             'allow expression without names' => [


### PR DESCRIPTION
This is a long-time-lasted feature for the `ExpressionLanguage` component. I've been waiting for the support of `Nullsafe operator` in expressions dealing with mutable objects, until I finally decided to work on it once for all 👍 

The lack of [nullsafety feature](https://wiki.php.net/rfc/nullsafe_operator) has been repeatedly reported as a BUG several time  (e.g [#45411](https://github.com/symfony/symfony/issues/45411) & [#21691](https://github.com/symfony/symfony/issues/21691)) when it is actually a missing feature.

Currently, expressions like `foo.bar` assumes that the property `bar` "always" exists on the object `foo` and if doesn't the parser throws a `RuntimeException`. Although, sometimes, that's exactly the behavior we need, some other times we may work with mutable objects with uncontrolled structure, thus, such assumption is error-prone and will force adding extra checks making the expression uglier and less readable.

The proposed work, introduces the support for the `?.` syntax alongside with the usual `.` syntax to help working with objects with dynamic structure. The two notations works identically in all normal cases. The difference occurs when trying to access non-existant properties and/or methods where the `.` notation will throw a `RuntimeException` as usual and the `?.` notation will return `null` instead and no errors nor exceptions will be thrown. Hence the name "Null-Safe".

PS: This work account ONLY for accessing **object's** properties and methods. It does not account for non-existant **array** items which is a seperate problem that can be addressed by introducing the [null coalescing](https://wiki.php.net/rfc/isset_ternary) operator. Another feature that I'm currently working on as well 💯 